### PR TITLE
Added a provider to allow the ES client to be accessed via the resource request scope

### DIFF
--- a/src/main/java/io/dropwizard/elasticsearch/provider/EsProvider.java
+++ b/src/main/java/io/dropwizard/elasticsearch/provider/EsProvider.java
@@ -1,0 +1,44 @@
+package io.dropwizard.elasticsearch.provider;
+
+import io.dropwizard.elasticsearch.managed.ManagedEsClient;
+import org.elasticsearch.client.Client;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+
+public class EsProvider implements Factory<Client> {
+
+    private static class Binder extends AbstractBinder {
+        private final EsProvider EsProvider;
+
+        public Binder(ManagedEsClient esClient) {
+            EsProvider = new EsProvider(esClient);
+        }
+
+        @Override
+        protected void configure() {
+            bindFactory(EsProvider).to(Client.class).in(RequestScoped.class);
+        }
+    }
+
+    public static Binder binder(ManagedEsClient esClient) {
+        return new Binder(esClient);
+    }
+
+    private final ManagedEsClient esClient;
+
+    private EsProvider(ManagedEsClient esClient) {
+        this.esClient = esClient;
+    }
+
+    @Override
+    public Client provide() {
+        return esClient.getClient();
+    }
+
+    @Override
+    public void dispose(Client client) {
+        client.close();
+    }
+
+}


### PR DESCRIPTION
Hello,

You can now access the client via the the request scope:

By registering the provider in the application run method:

```java
environment.jersey().register(EsProvider.binder(managedClient));
```

You will be able to access the client via an injected parameter in the resource method:

```java
public List<Message> getMessages(@Context Client es) {
    SearchResponse response = es.prepareSearch etc.
}
```

Please let me know If I haven't correctly implemented the provider...

Thank you for the project!